### PR TITLE
Open files lazyily

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -90,7 +90,8 @@ private slots:
     void redo();
 
 private:
-    void loadSettings(const QStringList &);
+    void loadSettings();
+    void loadFiles(const QStringList &);
     void saveSettings();
     void updateOpened();
     void openRecent();


### PR DESCRIPTION
Warning: Haven't tested it thoroughly but seems to work. The idea is to
let mainWindow contruct and start loading files in the next iteration of
the event loop.

Also, have raised the limit before warning is shown to 1MB since 50KB is too small imo.